### PR TITLE
Add divan benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "bitflags"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+
+[[package]]
 name = "borsh"
 version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -26,10 +38,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "clap"
+version = "4.5.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+ "terminal_size",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "condtype"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
+
+[[package]]
+name = "divan"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0583193020b29b03682d8d33bb53a5b0f50df6daacece12ca99b904cfdcb8c4"
+dependencies = [
+ "cfg-if",
+ "clap",
+ "condtype",
+ "divan-macros",
+ "libc",
+ "regex-lite",
+]
+
+[[package]]
+name = "divan-macros"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dc51d98e636f5e3b0759a39257458b22619cac7e96d932da6eeb052891bb67c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "equivalent"
@@ -38,10 +113,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "errno"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "fastborsh"
 version = "0.1.0"
 dependencies = [
  "borsh",
+ "divan",
  "fastborsh-core",
  "fastborsh-derive",
 ]
@@ -76,6 +162,18 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
+
+[[package]]
+name = "libc"
+version = "0.2.169"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "memchr"
@@ -117,6 +215,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +242,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
+dependencies = [
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -149,6 +276,79 @@ name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/fastborsh/Cargo.toml
+++ b/fastborsh/Cargo.toml
@@ -9,3 +9,9 @@ fastborsh-derive = { path = "../fastborsh-derive" }
 
 [dev-dependencies]
 borsh = { workspace = true, features = ["derive"] }
+
+divan = "0.1.17"
+
+[[bench]]
+name = "borsh"
+harness = false

--- a/fastborsh/benches/borsh.rs
+++ b/fastborsh/benches/borsh.rs
@@ -1,0 +1,36 @@
+use borsh::BorshSerialize;
+use divan::{black_box, Bencher};
+use fastborsh::{BorshSize, FastBorshSerialize};
+
+#[derive(Default, BorshSerialize, BorshSize)]
+struct Struck {
+    a: u32,
+    b: u64,
+    c: [u8; 32],
+    d: Vec<u8>,
+}
+
+#[divan::bench(args = 800..=1100, min_time = 0.2)]
+fn fast(bencher: Bencher, n: usize) {
+    let mut s = Struck::default();
+    s.d = vec![5; n];
+
+    bencher.bench(|| {
+        black_box(s.fast_serialize());
+    });
+}
+
+#[divan::bench(args = 800..=1100, min_time = 0.2)]
+fn borsh(bencher: Bencher, n: usize) {
+    let mut s = Struck::default();
+    s.d = vec![5; n];
+
+    bencher.bench(|| {
+        borsh::to_vec(&s).unwrap();
+    });
+}
+
+fn main() {
+    // Run registered benchmarks.
+    divan::main();
+}

--- a/fastborsh/benches/borsh.rs
+++ b/fastborsh/benches/borsh.rs
@@ -16,7 +16,7 @@ fn fast(bencher: Bencher, n: usize) {
     s.d = vec![5; n];
 
     bencher.bench(|| {
-        black_box(s.fast_serialize());
+        black_box(black_box(&s).fast_serialize());
     });
 }
 
@@ -26,7 +26,7 @@ fn borsh(bencher: Bencher, n: usize) {
     s.d = vec![5; n];
 
     bencher.bench(|| {
-        borsh::to_vec(&s).unwrap();
+        black_box(borsh::to_vec(black_box(&s)).unwrap());
     });
 }
 


### PR DESCRIPTION
Add a divan benchmark to test all values in the range of 800 to 1100.

For reference, here is my result:

```

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

borsh       fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ borsh                  │               │               │               │         │
│  ├─ 800   17.64 ns      │ 962.1 ns      │ 18.25 ns      │ 19.26 ns      │ 134260  │ 8592640
│  ├─ 801   18.39 ns      │ 586.8 ns      │ 19.13 ns      │ 19.6 ns       │ 136012  │ 8704768
│  ├─ 802   18.39 ns      │ 669.8 ns      │ 19.13 ns      │ 19.5 ns       │ 137191  │ 8780224
│  ├─ 803   18.39 ns      │ 1.115 µs      │ 19 ns         │ 19.5 ns       │ 137086  │ 8773504
│  ├─ 804   17.64 ns      │ 1.049 µs      │ 18.39 ns      │ 18.71 ns      │ 142127  │ 9096128
│  ├─ 805   18.39 ns      │ 1.187 µs      │ 19 ns         │ 19.55 ns      │ 136867  │ 8759488
│  ├─ 806   18.35 ns      │ 794.3 ns      │ 19.13 ns      │ 19.56 ns      │ 136645  │ 8745280
│  ├─ 807   18.35 ns      │ 645.4 ns      │ 19.1 ns       │ 20.27 ns      │ 131642  │ 8425088
│  ├─ 808   17.6 ns       │ 1.029 µs      │ 18.21 ns      │ 18.87 ns      │ 140845  │ 9014080
│  ├─ 809   18.64 ns      │ 1.618 µs      │ 19.25 ns      │ 19.95 ns      │ 134275  │ 8593600
│  ├─ 810   18.49 ns      │ 824.6 ns      │ 19.25 ns      │ 19.63 ns      │ 136460  │ 8733440
│  ├─ 811   18.5 ns       │ 1.208 µs      │ 19.24 ns      │ 19.59 ns      │ 136739  │ 8751296
│  ├─ 812   17.75 ns      │ 1.001 µs      │ 18.35 ns      │ 18.71 ns      │ 142145  │ 9097280
│  ├─ 813   18.64 ns      │ 839.6 ns      │ 19.39 ns      │ 19.76 ns      │ 135545  │ 8674880
│  ├─ 814   18.5 ns       │ 1.139 µs      │ 19.24 ns      │ 19.68 ns      │ 136145  │ 8713280
│  ├─ 815   18.49 ns      │ 1.113 µs      │ 19.24 ns      │ 19.55 ns      │ 136910  │ 8762240
│  ├─ 816   17.6 ns       │ 699.4 ns      │ 18.05 ns      │ 18.55 ns      │ 143094  │ 9158016
│  ├─ 817   18.64 ns      │ 565.2 ns      │ 19.25 ns      │ 19.67 ns      │ 136174  │ 8715136
│  ├─ 818   18.64 ns      │ 938.4 ns      │ 19.25 ns      │ 19.79 ns      │ 135347  │ 8662208
│  ├─ 819   18.64 ns      │ 972.9 ns      │ 19.24 ns      │ 19.7 ns       │ 135879  │ 8696256
│  ├─ 820   17.77 ns      │ 991.2 ns      │ 18.35 ns      │ 18.68 ns      │ 142307  │ 9107648
│  ├─ 821   18.64 ns      │ 529.6 ns      │ 19.24 ns      │ 19.67 ns      │ 136141  │ 8713024
│  ├─ 822   18.64 ns      │ 821.3 ns      │ 19.39 ns      │ 19.88 ns      │ 134846  │ 8630144
│  ├─ 823   18.64 ns      │ 751.3 ns      │ 19.38 ns      │ 19.82 ns      │ 134958  │ 8637312
│  ├─ 824   17.75 ns      │ 865.6 ns      │ 18.36 ns      │ 18.78 ns      │ 141491  │ 9055424
│  ├─ 825   19.1 ns       │ 939.6 ns      │ 19.99 ns      │ 20.32 ns      │ 132406  │ 8473984
│  ├─ 826   19.08 ns      │ 1.406 µs      │ 19.99 ns      │ 20.53 ns      │ 131092  │ 8389888
│  ├─ 827   19.08 ns      │ 1.022 µs      │ 19.99 ns      │ 20.59 ns      │ 130743  │ 8367552
│  ├─ 828   18.35 ns      │ 951.3 ns      │ 19.1 ns       │ 19.57 ns      │ 136621  │ 8743744
│  ├─ 829   19.08 ns      │ 763.9 ns      │ 19.99 ns      │ 20.5 ns       │ 131237  │ 8399168
│  ├─ 830   19.1 ns       │ 1.052 µs      │ 20.13 ns      │ 20.6 ns       │ 130674  │ 8363136
│  ├─ 831   19.1 ns       │ 1.192 µs      │ 19.99 ns      │ 20.55 ns      │ 130855  │ 8374720
│  ├─ 832   18.21 ns      │ 860.3 ns      │ 18.96 ns      │ 19.37 ns      │ 137812  │ 8819968
│  ├─ 833   19.1 ns       │ 759.8 ns      │ 19.99 ns      │ 20.37 ns      │ 132088  │ 8453632
│  ├─ 834   19.24 ns      │ 11.7 µs       │ 20.13 ns      │ 21.38 ns      │ 125834  │ 8053376
│  ├─ 835   19.24 ns      │ 706 ns        │ 19.99 ns      │ 20.5 ns       │ 131285  │ 8402240
│  ├─ 836   18.49 ns      │ 1.207 µs      │ 19.24 ns      │ 19.64 ns      │ 136164  │ 8714496
│  ├─ 837   19.1 ns       │ 907.3 ns      │ 20.13 ns      │ 20.68 ns      │ 130146  │ 8329344
│  ├─ 838   19.38 ns      │ 1.609 µs      │ 20.57 ns      │ 21.04 ns      │ 240399  │ 7692768
│  ├─ 839   19.24 ns      │ 748.6 ns      │ 19.99 ns      │ 20.6 ns       │ 130616  │ 8359424
│  ├─ 840   18.49 ns      │ 799.5 ns      │ 19.24 ns      │ 19.64 ns      │ 136031  │ 8705984
│  ├─ 841   18.49 ns      │ 762.2 ns      │ 19.1 ns       │ 19.55 ns      │ 136970  │ 8766080
│  ├─ 842   18.49 ns      │ 1.045 µs      │ 19.1 ns       │ 19.56 ns      │ 136801  │ 8755264
│  ├─ 843   18.49 ns      │ 782.7 ns      │ 19.1 ns       │ 19.55 ns      │ 136660  │ 8746240
│  ├─ 844   17.75 ns      │ 914.4 ns      │ 18.21 ns      │ 18.55 ns      │ 143230  │ 9166720
│  ├─ 845   18.49 ns      │ 658.7 ns      │ 19.08 ns      │ 19.43 ns      │ 137717  │ 8813888
│  ├─ 846   18.49 ns      │ 648.1 ns      │ 19.1 ns       │ 19.51 ns      │ 137192  │ 8780288
│  ├─ 847   18.5 ns       │ 1.467 µs      │ 19.11 ns      │ 19.58 ns      │ 136649  │ 8745536
│  ├─ 848   17.46 ns      │ 1.603 µs      │ 18.07 ns      │ 18.48 ns      │ 143443  │ 9180352
│  ├─ 849   18.21 ns      │ 733.5 ns      │ 18.96 ns      │ 19.45 ns      │ 137351  │ 8790464
│  ├─ 850   18.35 ns      │ 1.312 µs      │ 18.96 ns      │ 19.5 ns       │ 137053  │ 8771392
│  ├─ 851   18.5 ns       │ 1.927 µs      │ 19.41 ns      │ 20.03 ns      │ 250312  │ 8009984
│  ├─ 852   17.75 ns      │ 1.39 µs       │ 18.35 ns      │ 18.66 ns      │ 142507  │ 9120448
│  ├─ 853   18.35 ns      │ 1.602 µs      │ 19.1 ns       │ 19.49 ns      │ 137189  │ 8780096
│  ├─ 854   18.35 ns      │ 943.4 ns      │ 18.96 ns      │ 19.33 ns      │ 138220  │ 8846080
│  ├─ 855   18.35 ns      │ 858.2 ns      │ 18.96 ns      │ 19.38 ns      │ 137822  │ 8820608
│  ├─ 856   17.75 ns      │ 1.702 µs      │ 18.36 ns      │ 18.76 ns      │ 141691  │ 9068224
│  ├─ 857   18.35 ns      │ 902.8 ns      │ 18.96 ns      │ 19.41 ns      │ 137677  │ 8811328
│  ├─ 858   18.35 ns      │ 944.7 ns      │ 19.1 ns       │ 19.58 ns      │ 136544  │ 8738816
│  ├─ 859   18.22 ns      │ 1.28 µs       │ 18.96 ns      │ 19.49 ns      │ 137118  │ 8775552
│  ├─ 860   17.75 ns      │ 570.6 ns      │ 18.36 ns      │ 19.02 ns      │ 139681  │ 8939584
│  ├─ 861   18.5 ns       │ 1.818 µs      │ 19.41 ns      │ 20.25 ns      │ 247445  │ 7918240
│  ├─ 862   18.35 ns      │ 602.7 ns      │ 18.96 ns      │ 19.4 ns       │ 137780  │ 8817920
│  ├─ 863   18.35 ns      │ 1.107 µs      │ 18.96 ns      │ 19.53 ns      │ 136803  │ 8755392
│  ├─ 864   17.75 ns      │ 716 ns        │ 18.21 ns      │ 18.48 ns      │ 143803  │ 9203392
│  ├─ 865   18.35 ns      │ 761.8 ns      │ 18.96 ns      │ 19.49 ns      │ 137131  │ 8776384
│  ├─ 866   18.35 ns      │ 848.6 ns      │ 18.96 ns      │ 19.5 ns       │ 137112  │ 8775168
│  ├─ 867   18.35 ns      │ 1.349 µs      │ 19.1 ns       │ 20.14 ns      │ 132654  │ 8489856
│  ├─ 868   17.75 ns      │ 946.3 ns      │ 18.36 ns      │ 19.41 ns      │ 136763  │ 8752832
│  ├─ 869   18.35 ns      │ 779.3 ns      │ 19.1 ns       │ 19.79 ns      │ 135044  │ 8642816
│  ├─ 870   18.35 ns      │ 1.944 µs      │ 19.1 ns       │ 19.8 ns       │ 134995  │ 8639680
│  ├─ 871   18.35 ns      │ 1.664 µs      │ 19.25 ns      │ 20.16 ns      │ 132480  │ 8478720
│  ├─ 872   17.61 ns      │ 1.404 µs      │ 18.35 ns      │ 19.16 ns      │ 138573  │ 8868672
│  ├─ 873   19.24 ns      │ 887.8 ns      │ 20.3 ns       │ 21.1 ns       │ 127658  │ 8170112
│  ├─ 874   19.39 ns      │ 859.1 ns      │ 20.28 ns      │ 21.18 ns      │ 127103  │ 8134592
│  ├─ 875   19.25 ns      │ 1.034 µs      │ 20.3 ns       │ 20.85 ns      │ 129228  │ 8270592
│  ├─ 876   18.66 ns      │ 1.143 µs      │ 19.69 ns      │ 20.18 ns      │ 132882  │ 8504448
│  ├─ 877   19.39 ns      │ 844.4 ns      │ 20.28 ns      │ 20.68 ns      │ 130325  │ 8340800
│  ├─ 878   19.39 ns      │ 1.334 µs      │ 20.44 ns      │ 20.95 ns      │ 128723  │ 8238272
│  ├─ 879   19.24 ns      │ 5.304 µs      │ 20.44 ns      │ 22.48 ns      │ 119411  │ 7642304
│  ├─ 880   18.64 ns      │ 1.683 µs      │ 19.53 ns      │ 19.94 ns      │ 134315  │ 8596160
│  ├─ 881   19.25 ns      │ 721 ns        │ 20.3 ns       │ 20.84 ns      │ 129497  │ 8287808
│  ├─ 882   19.39 ns      │ 1.412 µs      │ 20.3 ns       │ 20.77 ns      │ 129882  │ 8312448
│  ├─ 883   19.39 ns      │ 863.4 ns      │ 20.28 ns      │ 20.71 ns      │ 130181  │ 8331584
│  ├─ 884   18.66 ns      │ 1.028 µs      │ 19.69 ns      │ 19.97 ns      │ 134271  │ 8593344
│  ├─ 885   19.24 ns      │ 1.15 µs       │ 20.3 ns       │ 20.9 ns       │ 128937  │ 8251968
│  ├─ 886   19.39 ns      │ 1.882 µs      │ 20.3 ns       │ 20.99 ns      │ 128552  │ 8227328
│  ├─ 887   19.38 ns      │ 15.78 µs      │ 20.88 ns      │ 22.11 ns      │ 228720  │ 7319040
│  ├─ 888   18.66 ns      │ 657.4 ns      │ 19.55 ns      │ 19.93 ns      │ 134587  │ 8613568
│  ├─ 889   19.1 ns       │ 1.088 µs      │ 20 ns         │ 20.51 ns      │ 131170  │ 8394880
│  ├─ 890   19.1 ns       │ 853.1 ns      │ 20 ns         │ 20.58 ns      │ 130622  │ 8359808
│  ├─ 891   18.96 ns      │ 1.392 µs      │ 19.99 ns      │ 20.38 ns      │ 132048  │ 8451072
│  ├─ 892   18.5 ns       │ 1.355 µs      │ 19.25 ns      │ 19.71 ns      │ 135699  │ 8684736
│  ├─ 893   19.1 ns       │ 1.17 µs       │ 19.99 ns      │ 20.46 ns      │ 131449  │ 8412736
│  ├─ 894   18.96 ns      │ 1.077 µs      │ 20 ns         │ 20.44 ns      │ 131625  │ 8424000
│  ├─ 895   19.1 ns       │ 998.2 ns      │ 19.86 ns      │ 20.49 ns      │ 131218  │ 8397952
│  ├─ 896   18.35 ns      │ 1.056 µs      │ 19.11 ns      │ 19.61 ns      │ 136363  │ 8727232
│  ├─ 897   18.96 ns      │ 1.246 µs      │ 20 ns         │ 20.56 ns      │ 130872  │ 8375808
│  ├─ 898   19.1 ns       │ 814.6 ns      │ 19.99 ns      │ 20.31 ns      │ 132454  │ 8477056
│  ├─ 899   19.1 ns       │ 927.2 ns      │ 20 ns         │ 20.38 ns      │ 132016  │ 8449024
│  ├─ 900   18.5 ns       │ 769.8 ns      │ 19.25 ns      │ 19.63 ns      │ 136256  │ 8720384
│  ├─ 901   19.1 ns       │ 966.5 ns      │ 20 ns         │ 20.57 ns      │ 130930  │ 8379520
│  ├─ 902   19.1 ns       │ 765 ns        │ 19.86 ns      │ 20.27 ns      │ 132621  │ 8487744
│  ├─ 903   19.1 ns       │ 465.5 ns      │ 20 ns         │ 20.5 ns       │ 131201  │ 8396864
│  ├─ 904   18.36 ns      │ 1.727 µs      │ 19.25 ns      │ 19.67 ns      │ 136002  │ 8704128
│  ├─ 905   18.5 ns       │ 813.4 ns      │ 19.1 ns       │ 19.53 ns      │ 136973  │ 8766272
│  ├─ 906   18.5 ns       │ 1.084 µs      │ 19.1 ns       │ 19.63 ns      │ 136273  │ 8721472
│  ├─ 907   18.5 ns       │ 890.1 ns      │ 19.1 ns       │ 19.5 ns       │ 137203  │ 8780992
│  ├─ 908   17.75 ns      │ 702.4 ns      │ 18.36 ns      │ 18.71 ns      │ 142091  │ 9093824
│  ├─ 909   18.21 ns      │ 821.9 ns      │ 19.1 ns       │ 19.58 ns      │ 136658  │ 8746112
│  ├─ 910   18.5 ns       │ 683.3 ns      │ 19.11 ns      │ 19.55 ns      │ 136815  │ 8756160
│  ├─ 911   18.36 ns      │ 788.8 ns      │ 19.1 ns       │ 19.53 ns      │ 136917  │ 8762688
│  ├─ 912   17.61 ns      │ 819.9 ns      │ 18.07 ns      │ 18.42 ns      │ 144096  │ 9222144
│  ├─ 913   19.25 ns      │ 13.07 µs      │ 20 ns         │ 21.86 ns      │ 122657  │ 7850048
│  ├─ 914   19.1 ns       │ 1.884 µs      │ 19.99 ns      │ 20.54 ns      │ 130906  │ 8377984
│  ├─ 915   19.25 ns      │ 931.5 ns      │ 19.99 ns      │ 20.5 ns       │ 131138  │ 8392832
│  ├─ 916   18.5 ns       │ 817.6 ns      │ 19.25 ns      │ 19.62 ns      │ 136251  │ 8720064
│  ├─ 917   19.25 ns      │ 796.1 ns      │ 19.85 ns      │ 20.27 ns      │ 132577  │ 8484928
│  ├─ 918   19.25 ns      │ 2.425 µs      │ 19.86 ns      │ 20.55 ns      │ 130740  │ 8367360
│  ├─ 919   19.25 ns      │ 1.337 µs      │ 19.99 ns      │ 20.52 ns      │ 131083  │ 8389312
│  ├─ 920   18.64 ns      │ 1.378 µs      │ 19.25 ns      │ 20.05 ns      │ 133082  │ 8517248
│  ├─ 921   19.25 ns      │ 896.8 ns      │ 19.99 ns      │ 20.61 ns      │ 130434  │ 8347776
│  ├─ 922   19.1 ns       │ 1.179 µs      │ 19.85 ns      │ 20.65 ns      │ 130030  │ 8321920
│  ├─ 923   19.1 ns       │ 2.332 µs      │ 19.85 ns      │ 20.62 ns      │ 130269  │ 8337216
│  ├─ 924   18.35 ns      │ 1.218 µs      │ 19.11 ns      │ 19.88 ns      │ 134207  │ 8589248
│  ├─ 925   19.1 ns       │ 698.8 ns      │ 20 ns         │ 20.73 ns      │ 129490  │ 8287360
│  ├─ 926   19.1 ns       │ 1.084 µs      │ 19.89 ns      │ 20.42 ns      │ 131657  │ 8426048
│  ├─ 927   19.13 ns      │ 1.648 µs      │ 19.89 ns      │ 20.54 ns      │ 130667  │ 8362688
│  ├─ 928   18.39 ns      │ 1.504 µs      │ 19.14 ns      │ 19.72 ns      │ 135360  │ 8663040
│  ├─ 929   19.13 ns      │ 1.51 µs       │ 19.88 ns      │ 20.38 ns      │ 131857  │ 8438848
│  ├─ 930   19.13 ns      │ 1.074 µs      │ 20.02 ns      │ 20.45 ns      │ 131430  │ 8411520
│  ├─ 931   19.13 ns      │ 1.403 µs      │ 19.88 ns      │ 20.52 ns      │ 131003  │ 8384192
│  ├─ 932   18.39 ns      │ 893.8 ns      │ 19.14 ns      │ 19.64 ns      │ 135944  │ 8700416
│  ├─ 933   19.13 ns      │ 578.8 ns      │ 20.03 ns      │ 20.44 ns      │ 131453  │ 8412992
│  ├─ 934   19.13 ns      │ 949.9 ns      │ 20.03 ns      │ 20.45 ns      │ 131449  │ 8412736
│  ├─ 935   19.13 ns      │ 1.048 µs      │ 19.88 ns      │ 20.29 ns      │ 132453  │ 8476992
│  ├─ 936   18.39 ns      │ 1.564 µs      │ 19.14 ns      │ 19.66 ns      │ 135842  │ 8693888
│  ├─ 937   20.17 ns      │ 1.033 µs      │ 20.78 ns      │ 21.33 ns      │ 126833  │ 8117312
│  ├─ 938   20.17 ns      │ 806.3 ns      │ 20.78 ns      │ 21.33 ns      │ 126828  │ 8116992
│  ├─ 939   19.89 ns      │ 719.2 ns      │ 20.92 ns      │ 21.38 ns      │ 126528  │ 8097792
│  ├─ 940   19.42 ns      │ 14.12 µs      │ 20.03 ns      │ 21.52 ns      │ 125023  │ 8001472
│  ├─ 941   20.02 ns      │ 5.105 µs      │ 20.92 ns      │ 22.31 ns      │ 121114  │ 7751296
│  ├─ 942   20.17 ns      │ 1.419 µs      │ 20.92 ns      │ 21.52 ns      │ 125668  │ 8042752
│  ├─ 943   20.02 ns      │ 1.118 µs      │ 20.92 ns      │ 21.47 ns      │ 125980  │ 8062720
│  ├─ 944   19.13 ns      │ 1.07 µs       │ 19.88 ns      │ 20.34 ns      │ 131991  │ 8447424
│  ├─ 945   20.02 ns      │ 919.9 ns      │ 21.07 ns      │ 21.59 ns      │ 125424  │ 8027136
│  ├─ 946   20.02 ns      │ 1.031 µs      │ 20.92 ns      │ 21.43 ns      │ 126312  │ 8083968
│  ├─ 947   20.02 ns      │ 1.051 µs      │ 20.92 ns      │ 21.51 ns      │ 125833  │ 8053312
│  ├─ 948   19.28 ns      │ 1.471 µs      │ 20.03 ns      │ 20.5 ns       │ 131122  │ 8391808
│  ├─ 949   20.03 ns      │ 1.284 µs      │ 20.78 ns      │ 21.42 ns      │ 126270  │ 8081280
│  ├─ 950   20.17 ns      │ 647.5 ns      │ 20.92 ns      │ 21.33 ns      │ 126764  │ 8112896
│  ├─ 951   20.03 ns      │ 1.015 µs      │ 20.92 ns      │ 21.42 ns      │ 126339  │ 8085696
│  ├─ 952   19.28 ns      │ 691.1 ns      │ 20.03 ns      │ 20.41 ns      │ 131760  │ 8432640
│  ├─ 953   20.02 ns      │ 1.323 µs      │ 20.92 ns      │ 21.45 ns      │ 125929  │ 8059456
│  ├─ 954   20.02 ns      │ 1.092 µs      │ 20.92 ns      │ 21.56 ns      │ 125360  │ 8023040
│  ├─ 955   19.88 ns      │ 956.6 ns      │ 20.92 ns      │ 21.92 ns      │ 123162  │ 7882368
│  ├─ 956   19.13 ns      │ 1.779 µs      │ 20.02 ns      │ 20.56 ns      │ 130642  │ 8361088
│  ├─ 957   19.88 ns      │ 850.1 ns      │ 20.78 ns      │ 21.44 ns      │ 126016  │ 8065024
│  ├─ 958   20.02 ns      │ 940.3 ns      │ 20.92 ns      │ 21.45 ns      │ 126090  │ 8069760
│  ├─ 959   19.88 ns      │ 1.126 µs      │ 20.92 ns      │ 21.48 ns      │ 125787  │ 8050368
│  ├─ 960   18.99 ns      │ 448.1 ns      │ 19.74 ns      │ 20.18 ns      │ 132854  │ 8502656
│  ├─ 961   20.02 ns      │ 941.3 ns      │ 20.92 ns      │ 21.48 ns      │ 125930  │ 8059520
│  ├─ 962   20.02 ns      │ 757.2 ns      │ 20.92 ns      │ 21.47 ns      │ 125920  │ 8058880
│  ├─ 963   20.02 ns      │ 700.1 ns      │ 20.92 ns      │ 21.32 ns      │ 126830  │ 8117120
│  ├─ 964   19.28 ns      │ 770.7 ns      │ 20.03 ns      │ 20.49 ns      │ 131168  │ 8394752
│  ├─ 965   20.02 ns      │ 899.4 ns      │ 20.92 ns      │ 21.36 ns      │ 126585  │ 8101440
│  ├─ 966   19.97 ns      │ 808.8 ns      │ 20.88 ns      │ 21.5 ns       │ 125832  │ 8053248
│  ├─ 967   19.97 ns      │ 942.4 ns      │ 21.02 ns      │ 22.03 ns      │ 122620  │ 7847680
│  ├─ 968   19.1 ns       │ 932.8 ns      │ 19.99 ns      │ 20.5 ns       │ 131097  │ 8390208
│  ├─ 969   19.38 ns      │ 551.1 ns      │ 20.13 ns      │ 20.53 ns      │ 131037  │ 8386368
│  ├─ 970   19.38 ns      │ 575.3 ns      │ 19.99 ns      │ 20.48 ns      │ 131438  │ 8412032
│  ├─ 971   19.38 ns      │ 1.003 µs      │ 20.13 ns      │ 20.59 ns      │ 130715  │ 8365760
│  ├─ 972   18.49 ns      │ 754.4 ns      │ 19.24 ns      │ 19.75 ns      │ 135234  │ 8654976
│  ├─ 973   19.24 ns      │ 983.2 ns      │ 20.14 ns      │ 20.64 ns      │ 130491  │ 8351424
│  ├─ 974   19.24 ns      │ 947.9 ns      │ 20.13 ns      │ 20.55 ns      │ 130981  │ 8382784
│  ├─ 975   19.38 ns      │ 911.3 ns      │ 19.99 ns      │ 20.61 ns      │ 130553  │ 8355392
│  ├─ 976   18.19 ns      │ 1.673 µs      │ 18.8 ns       │ 19.32 ns      │ 138141  │ 8841024
│  ├─ 977   46.13 ns      │ 1.999 µs      │ 47.03 ns      │ 48.32 ns      │ 117498  │ 3759936
│  ├─ 978   46.13 ns      │ 1.551 µs      │ 47.32 ns      │ 48.29 ns      │ 117661  │ 3765152
│  ├─ 979   46.13 ns      │ 2.849 µs      │ 47.32 ns      │ 48.54 ns      │ 116973  │ 3743136
│  ├─ 980   45.82 ns      │ 3.788 µs      │ 47.03 ns      │ 48.54 ns      │ 116907  │ 3741024
│  ├─ 981   46.13 ns      │ 1.988 µs      │ 47.32 ns      │ 48.63 ns      │ 116772  │ 3736704
│  ├─ 982   46.13 ns      │ 2.098 µs      │ 47.03 ns      │ 48.28 ns      │ 117664  │ 3765248
│  ├─ 983   46.13 ns      │ 981.9 ns      │ 47.03 ns      │ 47.93 ns      │ 118477  │ 3791264
│  ├─ 984   45.82 ns      │ 1.83 µs       │ 47.03 ns      │ 48.21 ns      │ 117798  │ 3769536
│  ├─ 985   47 ns         │ 1.787 µs      │ 50.32 ns      │ 51.51 ns      │ 110820  │ 3546240
│  ├─ 986   46.72 ns      │ 2.991 µs      │ 50.32 ns      │ 51.53 ns      │ 110772  │ 3544704
│  ├─ 987   46.72 ns      │ 3.388 µs      │ 50.32 ns      │ 52.06 ns      │ 109600  │ 3507200
│  ├─ 988   47 ns         │ 1.865 µs      │ 50 ns         │ 51.32 ns      │ 111254  │ 3560128
│  ├─ 989   46.72 ns      │ 2.268 µs      │ 50.88 ns      │ 52.02 ns      │ 109625  │ 3508000
│  ├─ 990   46.72 ns      │ 2.258 µs      │ 50.6 ns       │ 51.94 ns      │ 109901  │ 3516832
│  ├─ 991   47 ns         │ 1.664 µs      │ 50.6 ns       │ 51.83 ns      │ 109954  │ 3518528
│  ├─ 992   46.72 ns      │ 2.374 µs      │ 50 ns         │ 51.94 ns      │ 109857  │ 3515424
│  ├─ 993   47 ns         │ 18.63 µs      │ 50.6 ns       │ 53.41 ns      │ 106965  │ 3422880
│  ├─ 994   46.72 ns      │ 2.627 µs      │ 50.6 ns       │ 51.65 ns      │ 110477  │ 3535264
│  ├─ 995   47 ns         │ 2.45 µs       │ 50.6 ns       │ 51.63 ns      │ 110564  │ 3538048
│  ├─ 996   46.13 ns      │ 3.202 µs      │ 50.28 ns      │ 51.23 ns      │ 111395  │ 3564640
│  ├─ 997   46.72 ns      │ 1.202 µs      │ 50.6 ns       │ 51.7 ns       │ 110343  │ 3530976
│  ├─ 998   46.72 ns      │ 2.282 µs      │ 50.57 ns      │ 51.78 ns      │ 110205  │ 3526560
│  ├─ 999   46.72 ns      │ 18.17 µs      │ 50.6 ns       │ 53.7 ns       │ 106316  │ 3402112
│  ├─ 1000  46.72 ns      │ 3.212 µs      │ 50.57 ns      │ 51.74 ns      │ 110231  │ 3527392
│  ├─ 1001  49.69 ns      │ 1.84 µs       │ 51.78 ns      │ 53.31 ns      │ 107060  │ 3425920
│  ├─ 1002  49.69 ns      │ 1.85 µs       │ 51.47 ns      │ 52.28 ns      │ 109310  │ 3497920
│  ├─ 1003  48.19 ns      │ 1.434 µs      │ 51.78 ns      │ 52.77 ns      │ 108300  │ 3465600
│  ├─ 1004  47.91 ns      │ 2.038 µs      │ 50.6 ns       │ 51.77 ns      │ 110222  │ 3527104
│  ├─ 1005  50.28 ns      │ 4.638 µs      │ 52.66 ns      │ 53.69 ns      │ 202596  │ 3241536
│  ├─ 1006  48.78 ns      │ 1.841 µs      │ 50.78 ns      │ 52.21 ns      │ 109373  │ 3499936
│  ├─ 1007  47.53 ns      │ 1.699 µs      │ 51.07 ns      │ 52.12 ns      │ 109660  │ 3509120
│  ├─ 1008  46.66 ns      │ 1.384 µs      │ 50.19 ns      │ 51.34 ns      │ 111018  │ 3552576
│  ├─ 1009  48.13 ns      │ 2.241 µs      │ 51.07 ns      │ 52.06 ns      │ 109766  │ 3512512
│  ├─ 1010  48.13 ns      │ 1.097 µs      │ 50.78 ns      │ 51.74 ns      │ 110373  │ 3531936
│  ├─ 1011  47.85 ns      │ 1.9 µs        │ 51.07 ns      │ 52.14 ns      │ 109484  │ 3503488
│  ├─ 1012  47.85 ns      │ 3.036 µs      │ 50.19 ns      │ 51.67 ns      │ 110365  │ 3531680
│  ├─ 1013  47.85 ns      │ 1.633 µs      │ 50.78 ns      │ 52.92 ns      │ 107822  │ 3450304
│  ├─ 1014  48.41 ns      │ 1.578 µs      │ 51.07 ns      │ 52.48 ns      │ 108872  │ 3483904
│  ├─ 1015  47.57 ns      │ 2.099 µs      │ 51.07 ns      │ 52.55 ns      │ 108652  │ 3476864
│  ├─ 1016  47.85 ns      │ 2.062 µs      │ 50.19 ns      │ 51.45 ns      │ 110932  │ 3549824
│  ├─ 1017  40.22 ns      │ 1.613 µs      │ 41.69 ns      │ 42.4 ns       │ 132509  │ 4240288
│  ├─ 1018  38.47 ns      │ 1.7 µs        │ 41.69 ns      │ 42.69 ns      │ 131568  │ 4210176
│  ├─ 1019  39.03 ns      │ 2.896 µs      │ 41.69 ns      │ 42.81 ns      │ 131237  │ 4199584
│  ├─ 1020  38.47 ns      │ 12.09 µs      │ 41.69 ns      │ 44.97 ns      │ 124613  │ 3987616
│  ├─ 1021  39.35 ns      │ 1.525 µs      │ 41.69 ns      │ 42.66 ns      │ 131657  │ 4213024
│  ├─ 1022  38.75 ns      │ 2.193 µs      │ 41.69 ns      │ 42.35 ns      │ 132716  │ 4246912
│  ├─ 1023  38.75 ns      │ 1.911 µs      │ 41.69 ns      │ 42.37 ns      │ 132567  │ 4242144
│  ├─ 1024  37.88 ns      │ 1.554 µs      │ 39.63 ns      │ 40.35 ns      │ 138535  │ 4433120
│  ├─ 1025  38.16 ns      │ 1.289 µs      │ 39.63 ns      │ 40.45 ns      │ 138162  │ 4421184
│  ├─ 1026  38.19 ns      │ 1.968 µs      │ 39.63 ns      │ 40.59 ns      │ 137587  │ 4402784
│  ├─ 1027  38.44 ns      │ 2.649 µs      │ 39.66 ns      │ 40.93 ns      │ 136518  │ 4368576
│  ├─ 1028  38.16 ns      │ 2.631 µs      │ 39.63 ns      │ 40.81 ns      │ 136936  │ 4381952
│  ├─ 1029  38.44 ns      │ 2.383 µs      │ 39.63 ns      │ 40.63 ns      │ 137490  │ 4399680
│  ├─ 1030  38.16 ns      │ 2.99 µs       │ 39.63 ns      │ 40.42 ns      │ 138210  │ 4422720
│  ├─ 1031  38.19 ns      │ 1.642 µs      │ 39.63 ns      │ 40.43 ns      │ 138198  │ 4422336
│  ├─ 1032  38.16 ns      │ 2.073 µs      │ 39.63 ns      │ 40.51 ns      │ 137915  │ 4413280
│  ├─ 1033  47.85 ns      │ 1.663 µs      │ 49 ns         │ 50.17 ns      │ 113686  │ 3637952
│  ├─ 1034  47.85 ns      │ 2.705 µs      │ 49.03 ns      │ 50.2 ns       │ 113649  │ 3636768
│  ├─ 1035  47.57 ns      │ 2.468 µs      │ 49.03 ns      │ 50.27 ns      │ 113442  │ 3630144
│  ├─ 1036  47.25 ns      │ 1.571 µs      │ 48.75 ns      │ 50.28 ns      │ 113366  │ 3627712
│  ├─ 1037  47.53 ns      │ 2.123 µs      │ 49.03 ns      │ 50.55 ns      │ 112798  │ 3609536
│  ├─ 1038  47.53 ns      │ 1.948 µs      │ 49.03 ns      │ 50.46 ns      │ 113039  │ 3617248
│  ├─ 1039  47.25 ns      │ 2.044 µs      │ 49.32 ns      │ 50.51 ns      │ 112868  │ 3611776
│  ├─ 1040  47.53 ns      │ 1.727 µs      │ 48.72 ns      │ 49.74 ns      │ 114622  │ 3667904
│  ├─ 1041  47.85 ns      │ 2.185 µs      │ 49.03 ns      │ 50.29 ns      │ 113399  │ 3628768
│  ├─ 1042  47.85 ns      │ 2.588 µs      │ 49.03 ns      │ 50.34 ns      │ 113268  │ 3624576
│  ├─ 1043  47.85 ns      │ 1.741 µs      │ 49.03 ns      │ 50.41 ns      │ 113086  │ 3618752
│  ├─ 1044  47.53 ns      │ 1.397 µs      │ 48.72 ns      │ 50.02 ns      │ 114000  │ 3648000
│  ├─ 1045  47.85 ns      │ 2.807 µs      │ 49.03 ns      │ 50.26 ns      │ 113426  │ 3629632
│  ├─ 1046  48.97 ns      │ 39.02 µs      │ 50.47 ns      │ 54.26 ns      │ 105153  │ 3364896
│  ├─ 1047  48.97 ns      │ 1.809 µs      │ 50.19 ns      │ 51.95 ns      │ 109754  │ 3512128
│  ├─ 1048  48.69 ns      │ 1.477 µs      │ 50.19 ns      │ 51.91 ns      │ 109868  │ 3515776
│  ├─ 1049  49.28 ns      │ 5.183 µs      │ 51.38 ns      │ 54.81 ns      │ 104107  │ 3331424
│  ├─ 1050  49.88 ns      │ 2.09 µs       │ 51.38 ns      │ 52.57 ns      │ 108488  │ 3471616
│  ├─ 1051  48.97 ns      │ 2.283 µs      │ 51.1 ns       │ 53.33 ns      │ 106916  │ 3421312
│  ├─ 1052  50.16 ns      │ 3.136 µs      │ 52.6 ns       │ 53.8 ns       │ 201996  │ 3231936
│  ├─ 1053  49 ns         │ 1.226 µs      │ 51.1 ns       │ 52.44 ns      │ 108782  │ 3481024
│  ├─ 1054  49.28 ns      │ 10.77 µs      │ 51.1 ns       │ 52.43 ns      │ 108869  │ 3483808
│  ├─ 1055  49.28 ns      │ 1.971 µs      │ 51.1 ns       │ 52.9 ns       │ 107847  │ 3451104
│  ├─ 1056  48.69 ns      │ 2.73 µs       │ 50.78 ns      │ 51.92 ns      │ 109935  │ 3517920
│  ├─ 1057  48.97 ns      │ 959.1 ns      │ 51.1 ns       │ 52.1 ns       │ 109507  │ 3504224
│  ├─ 1058  48.97 ns      │ 2.679 µs      │ 51.1 ns       │ 52.23 ns      │ 109285  │ 3497120
│  ├─ 1059  48.97 ns      │ 1.441 µs      │ 51.1 ns       │ 52.33 ns      │ 108974  │ 3487168
│  ├─ 1060  50.16 ns      │ 3.158 µs      │ 52.6 ns       │ 53.82 ns      │ 201961  │ 3231376
│  ├─ 1061  48.97 ns      │ 3.26 µs       │ 51.1 ns       │ 52.93 ns      │ 107718  │ 3446976
│  ├─ 1062  50.78 ns      │ 3.75 µs       │ 53.16 ns      │ 54.56 ns      │ 199453  │ 3191248
│  ├─ 1063  48.69 ns      │ 3.678 µs      │ 51.1 ns       │ 52.31 ns      │ 109039  │ 3489248
│  ├─ 1064  48.97 ns      │ 1.879 µs      │ 51.07 ns      │ 52.32 ns      │ 109075  │ 3490400
│  ├─ 1065  49.57 ns      │ 1.65 µs       │ 50.78 ns      │ 52.01 ns      │ 109761  │ 3512352
│  ├─ 1066  49.6 ns       │ 2.433 µs      │ 51.07 ns      │ 52.48 ns      │ 108614  │ 3475648
│  ├─ 1067  49.57 ns      │ 1.619 µs      │ 50.78 ns      │ 52.24 ns      │ 109167  │ 3493344
│  ├─ 1068  49.57 ns      │ 2.151 µs      │ 50.5 ns       │ 51.5 ns       │ 110828  │ 3546496
│  ├─ 1069  49.57 ns      │ 1.634 µs      │ 50.78 ns      │ 52.18 ns      │ 109432  │ 3501824
│  ├─ 1070  49.28 ns      │ 2.395 µs      │ 50.78 ns      │ 52.04 ns      │ 109743  │ 3511776
│  ├─ 1071  49.57 ns      │ 1.571 µs      │ 51.1 ns       │ 52.53 ns      │ 108506  │ 3472192
│  ├─ 1072  49.28 ns      │ 3.901 µs      │ 50.5 ns       │ 51.76 ns      │ 110362  │ 3531584
│  ├─ 1073  50.16 ns      │ 9.132 µs      │ 52.03 ns      │ 55.54 ns      │ 195676  │ 3130816
│  ├─ 1074  49.88 ns      │ 1.648 µs      │ 51.07 ns      │ 51.95 ns      │ 109833  │ 3514656
│  ├─ 1075  49.57 ns      │ 1.707 µs      │ 50.78 ns      │ 52.24 ns      │ 109197  │ 3494304
│  ├─ 1076  49.28 ns      │ 1.43 µs       │ 50.5 ns       │ 51.66 ns      │ 110486  │ 3535552
│  ├─ 1077  49.6 ns       │ 2.515 µs      │ 50.78 ns      │ 52.07 ns      │ 109680  │ 3509760
│  ├─ 1078  49.57 ns      │ 2.257 µs      │ 50.78 ns      │ 51.91 ns      │ 109962  │ 3518784
│  ├─ 1079  49.57 ns      │ 1.855 µs      │ 50.78 ns      │ 52.06 ns      │ 109632  │ 3508224
│  ├─ 1080  49.28 ns      │ 2.214 µs      │ 50.5 ns       │ 51.73 ns      │ 110296  │ 3529472
│  ├─ 1081  48.66 ns      │ 1.515 µs      │ 50.78 ns      │ 52.27 ns      │ 109064  │ 3490048
│  ├─ 1082  49.28 ns      │ 2.006 µs      │ 50.78 ns      │ 52.15 ns      │ 109395  │ 3500640
│  ├─ 1083  48.97 ns      │ 1.258 µs      │ 50.78 ns      │ 52.58 ns      │ 108463  │ 3470816
│  ├─ 1084  48.97 ns      │ 2.173 µs      │ 50.5 ns       │ 51.68 ns      │ 110385  │ 3532320
│  ├─ 1085  48.97 ns      │ 1.749 µs      │ 50.5 ns       │ 51.5 ns       │ 110799  │ 3545568
│  ├─ 1086  49.07 ns      │ 1.738 µs      │ 50.57 ns      │ 51.4 ns       │ 111037  │ 3553184
│  ├─ 1087  48.78 ns      │ 2.427 µs      │ 50.57 ns      │ 51.83 ns      │ 110125  │ 3524000
│  ├─ 1088  48.47 ns      │ 2.591 µs      │ 50.25 ns      │ 51.12 ns      │ 111567  │ 3570144
│  ├─ 1089  48.47 ns      │ 1.799 µs      │ 50.57 ns      │ 51.85 ns      │ 110100  │ 3523200
│  ├─ 1090  48.75 ns      │ 2.884 µs      │ 50.57 ns      │ 51.71 ns      │ 110308  │ 3529856
│  ├─ 1091  48.75 ns      │ 1.279 µs      │ 50.57 ns      │ 52.25 ns      │ 109273  │ 3496736
│  ├─ 1092  48.47 ns      │ 1.264 µs      │ 50.25 ns      │ 51.38 ns      │ 111065  │ 3554080
│  ├─ 1093  48.75 ns      │ 3.103 µs      │ 50.57 ns      │ 51.78 ns      │ 110222  │ 3527104
│  ├─ 1094  48.75 ns      │ 4.242 µs      │ 50.57 ns      │ 54.05 ns      │ 105638  │ 3380416
│  ├─ 1095  56.78 ns      │ 36.06 µs      │ 66.78 ns      │ 71.09 ns      │ 1102614 │ 1102614
│  ├─ 1096  48.75 ns      │ 1.143 µs      │ 50.28 ns      │ 51.5 ns       │ 110689  │ 3542048
│  ├─ 1097  49.07 ns      │ 1.702 µs      │ 50.57 ns      │ 51.36 ns      │ 111172  │ 3557504
│  ├─ 1098  49.07 ns      │ 1.272 µs      │ 50.85 ns      │ 51.81 ns      │ 110135  │ 3524320
│  ├─ 1099  49.07 ns      │ 17.88 µs      │ 50.85 ns      │ 55.94 ns      │ 101940  │ 3262080
│  ╰─ 1100  48.75 ns      │ 1.338 µs      │ 50.28 ns      │ 51.86 ns      │ 109914  │ 3517248
╰─ fast                   │               │               │               │         │
   ├─ 800   17.41 ns      │ 798.8 ns      │ 18.32 ns      │ 18.66 ns      │ 142241  │ 9103424
   ├─ 801   19.5 ns       │ 875.7 ns      │ 20.85 ns      │ 21.29 ns      │ 126893  │ 8121152
   ├─ 802   19.49 ns      │ 1.124 µs      │ 20.85 ns      │ 21.26 ns      │ 127223  │ 8142272
   ├─ 803   19.64 ns      │ 902.5 ns      │ 20.85 ns      │ 21.5 ns       │ 125728  │ 8046592
   ├─ 804   18.6 ns       │ 587.7 ns      │ 19.64 ns      │ 20.06 ns      │ 133455  │ 8541120
   ├─ 805   19.64 ns      │ 29.51 µs      │ 20.71 ns      │ 21.34 ns      │ 126865  │ 8119360
   ├─ 806   19.64 ns      │ 1.34 µs       │ 20.85 ns      │ 21.3 ns       │ 126974  │ 8126336
   ├─ 807   19.49 ns      │ 869.6 ns      │ 20.85 ns      │ 21.17 ns      │ 127721  │ 8174144
   ├─ 808   18.46 ns      │ 800 ns        │ 19.5 ns       │ 19.91 ns      │ 134617  │ 8615488
   ├─ 809   19.64 ns      │ 793.9 ns      │ 20.71 ns      │ 21.21 ns      │ 127408  │ 8154112
   ├─ 810   19.78 ns      │ 1.431 µs      │ 21.28 ns      │ 21.55 ns      │ 236132  │ 7556224
   ├─ 811   19.64 ns      │ 731.1 ns      │ 20.69 ns      │ 21.31 ns      │ 126728  │ 8110592
   ├─ 812   18.6 ns       │ 1.061 µs      │ 19.21 ns      │ 19.76 ns      │ 135428  │ 8667392
   ├─ 813   19.5 ns       │ 1.046 µs      │ 20.71 ns      │ 21.24 ns      │ 127221  │ 8142144
   ├─ 814   19.64 ns      │ 530.3 ns      │ 20.69 ns      │ 21.03 ns      │ 128434  │ 8219776
   ├─ 815   19.49 ns      │ 1.306 µs      │ 20.71 ns      │ 21.23 ns      │ 127208  │ 8141312
   ├─ 816   18.44 ns      │ 1.32 µs       │ 19.05 ns      │ 19.47 ns      │ 137344  │ 8790016
   ├─ 817   19.78 ns      │ 1.961 µs      │ 21.32 ns      │ 21.93 ns      │ 232350  │ 7435200
   ├─ 818   19.5 ns       │ 1.289 µs      │ 20.85 ns      │ 21.24 ns      │ 127252  │ 8144128
   ├─ 819   19.49 ns      │ 1.206 µs      │ 20.71 ns      │ 21.12 ns      │ 127899  │ 8185536
   ├─ 820   18.46 ns      │ 1.028 µs      │ 19.21 ns      │ 19.84 ns      │ 134934  │ 8635776
   ├─ 821   19.64 ns      │ 1.214 µs      │ 20.85 ns      │ 21.24 ns      │ 127350  │ 8150400
   ├─ 822   19.36 ns      │ 6.679 µs      │ 20.99 ns      │ 21.96 ns      │ 122833  │ 7861312
   ├─ 823   19.64 ns      │ 618.6 ns      │ 20.85 ns      │ 21.34 ns      │ 126634  │ 8104576
   ├─ 824   18.35 ns      │ 895.9 ns      │ 19.19 ns      │ 19.6 ns       │ 136572  │ 8740608
   ├─ 825   19.08 ns      │ 821.4 ns      │ 20.27 ns      │ 20.6 ns       │ 131010  │ 8384640
   ├─ 826   19.08 ns      │ 810.6 ns      │ 20.41 ns      │ 20.84 ns      │ 129434  │ 8283776
   ├─ 827   19.08 ns      │ 1.229 µs      │ 20.27 ns      │ 20.76 ns      │ 130108  │ 8326912
   ├─ 828   17.91 ns      │ 753.6 ns      │ 18.8 ns       │ 19.24 ns      │ 139018  │ 8897152
   ├─ 829   19.08 ns      │ 731 ns        │ 20.27 ns      │ 20.66 ns      │ 130496  │ 8351744
   ├─ 830   19.22 ns      │ 671.7 ns      │ 20.41 ns      │ 20.75 ns      │ 130174  │ 8331136
   ├─ 831   19.08 ns      │ 2.894 µs      │ 20.41 ns      │ 21.51 ns      │ 125111  │ 8007104
   ├─ 832   17.61 ns      │ 1.178 µs      │ 18.64 ns      │ 18.99 ns      │ 140476  │ 8990464
   ├─ 833   19.08 ns      │ 730.7 ns      │ 20.41 ns      │ 20.74 ns      │ 130210  │ 8333440
   ├─ 834   19.22 ns      │ 1.014 µs      │ 20.41 ns      │ 20.75 ns      │ 130099  │ 8326336
   ├─ 835   18.94 ns      │ 800.2 ns      │ 20.41 ns      │ 20.77 ns      │ 129958  │ 8317312
   ├─ 836   18.19 ns      │ 930 ns        │ 19.08 ns      │ 19.64 ns      │ 136302  │ 8723328
   ├─ 837   19.22 ns      │ 681.9 ns      │ 20.41 ns      │ 20.76 ns      │ 130158  │ 8330112
   ├─ 838   19.22 ns      │ 1.237 µs      │ 20.41 ns      │ 20.91 ns      │ 129287  │ 8274368
   ├─ 839   19.22 ns      │ 976.3 ns      │ 20.41 ns      │ 20.85 ns      │ 129432  │ 8283648
   ├─ 840   18.05 ns      │ 836.1 ns      │ 18.92 ns      │ 19.51 ns      │ 136907  │ 8762048
   ├─ 841   17.89 ns      │ 1.047 µs      │ 18.94 ns      │ 19.34 ns      │ 138064  │ 8836096
   ├─ 842   17.89 ns      │ 640.3 ns      │ 18.92 ns      │ 19.17 ns      │ 139330  │ 8917120
   ├─ 843   17.75 ns      │ 567.8 ns      │ 18.92 ns      │ 19.25 ns      │ 138819  │ 8884416
   ├─ 844   16.86 ns      │ 1.49 µs       │ 17.61 ns      │ 17.9 ns       │ 147679  │ 9451456
   ├─ 845   17.75 ns      │ 1.29 µs       │ 18.92 ns      │ 19.26 ns      │ 138617  │ 8871488
   ├─ 846   18.05 ns      │ 793.1 ns      │ 18.92 ns      │ 19.22 ns      │ 139014  │ 8896896
   ├─ 847   17.89 ns      │ 909.8 ns      │ 18.94 ns      │ 19.33 ns      │ 138133  │ 8840512
   ├─ 848   16.72 ns      │ 14.09 µs      │ 17.32 ns      │ 18.74 ns      │ 139059  │ 8899776
   ├─ 849   17.89 ns      │ 531.3 ns      │ 18.78 ns      │ 19.17 ns      │ 139170  │ 8906880
   ├─ 850   17.75 ns      │ 1.174 µs      │ 18.8 ns       │ 19.47 ns      │ 137035  │ 8770240
   ├─ 851   17.89 ns      │ 679.8 ns      │ 18.8 ns       │ 19.18 ns      │ 139206  │ 8909184
   ├─ 852   17.02 ns      │ 610.4 ns      │ 17.75 ns      │ 18.02 ns      │ 146946  │ 9404544
   ├─ 853   17.89 ns      │ 616.8 ns      │ 18.78 ns      │ 19.1 ns       │ 139746  │ 8943744
   ├─ 854   17.89 ns      │ 724.7 ns      │ 18.8 ns       │ 19.21 ns      │ 138876  │ 8888064
   ├─ 855   17.89 ns      │ 732.8 ns      │ 18.78 ns      │ 19.15 ns      │ 139434  │ 8923776
   ├─ 856   17.02 ns      │ 1.454 µs      │ 17.61 ns      │ 17.9 ns       │ 147853  │ 9462592
   ├─ 857   19.82 ns      │ 829.1 ns      │ 21.14 ns      │ 21.75 ns      │ 124759  │ 7984576
   ├─ 858   19.82 ns      │ 1.025 µs      │ 21 ns         │ 21.44 ns      │ 126582  │ 8101248
   ├─ 859   19.67 ns      │ 810.4 ns      │ 21 ns         │ 21.51 ns      │ 126099  │ 8070336
   ├─ 860   18.64 ns      │ 501.6 ns      │ 19.67 ns      │ 20.07 ns      │ 134004  │ 8576256
   ├─ 861   19.82 ns      │ 1.895 µs      │ 21 ns         │ 21.47 ns      │ 126351  │ 8086464
   ├─ 862   19.82 ns      │ 646.6 ns      │ 21 ns         │ 21.41 ns      │ 126590  │ 8101760
   ├─ 863   19.66 ns      │ 821.3 ns      │ 21 ns         │ 21.36 ns      │ 126954  │ 8125056
   ├─ 864   18.35 ns      │ 717.7 ns      │ 19.44 ns      │ 19.9 ns       │ 134578  │ 8612992
   ├─ 865   19.44 ns      │ 1.132 µs      │ 20.94 ns      │ 21.47 ns      │ 126139  │ 8072896
   ├─ 866   19.44 ns      │ 865.6 ns      │ 20.94 ns      │ 21.6 ns       │ 125328  │ 8020992
   ├─ 867   19.74 ns      │ 923.6 ns      │ 20.94 ns      │ 21.43 ns      │ 126332  │ 8085248
   ├─ 868   18.85 ns      │ 600.8 ns      │ 19.89 ns      │ 20.36 ns      │ 131939  │ 8444096
   ├─ 869   19.74 ns      │ 1.323 µs      │ 20.94 ns      │ 22.16 ns      │ 121729  │ 7790656
   ├─ 870   19.74 ns      │ 936.3 ns      │ 20.92 ns      │ 21.37 ns      │ 126618  │ 8103552
   ├─ 871   19.6 ns       │ 586.8 ns      │ 21.08 ns      │ 21.53 ns      │ 125704  │ 8045056
   ├─ 872   18.85 ns      │ 1.032 µs      │ 19.89 ns      │ 20.32 ns      │ 132320  │ 8468480
   ├─ 873   18.1 ns       │ 1.273 µs      │ 19.14 ns      │ 19.49 ns      │ 137092  │ 8773888
   ├─ 874   17.96 ns      │ 1.085 µs      │ 19.14 ns      │ 20.11 ns      │ 132641  │ 8489024
   ├─ 875   17.96 ns      │ 6.402 µs      │ 19.14 ns      │ 21.93 ns      │ 121237  │ 7759168
   ├─ 876   17.21 ns      │ 1.037 µs      │ 17.96 ns      │ 18.55 ns      │ 142679  │ 9131456
   ├─ 877   18.25 ns      │ 2.751 µs      │ 19.72 ns      │ 20.22 ns      │ 247811  │ 7929952
   ├─ 878   17.94 ns      │ 848.2 ns      │ 19.14 ns      │ 20.25 ns      │ 131864  │ 8439296
   ├─ 879   17.96 ns      │ 1.12 µs       │ 19.14 ns      │ 19.81 ns      │ 134797  │ 8627008
   ├─ 880   17.35 ns      │ 4.54 µs       │ 18.53 ns      │ 19.13 ns      │ 258963  │ 8286816
   ├─ 881   17.96 ns      │ 983.8 ns      │ 19.16 ns      │ 20.02 ns      │ 133273  │ 8529472
   ├─ 882   17.94 ns      │ 5.833 µs      │ 19.16 ns      │ 20.84 ns      │ 127894  │ 8185216
   ├─ 883   17.96 ns      │ 1.005 µs      │ 19.14 ns      │ 19.93 ns      │ 133847  │ 8566208
   ├─ 884   17.35 ns      │ 4.88 µs       │ 18.53 ns      │ 19.14 ns      │ 258855  │ 8283360
   ├─ 885   17.96 ns      │ 1.267 µs      │ 19.14 ns      │ 19.46 ns      │ 137205  │ 8781120
   ├─ 886   17.8 ns       │ 1.138 µs      │ 19 ns         │ 19.31 ns      │ 138208  │ 8845312
   ├─ 887   17.96 ns      │ 588.2 ns      │ 19.14 ns      │ 19.45 ns      │ 137348  │ 8790272
   ├─ 888   17.07 ns      │ 1.09 µs       │ 17.82 ns      │ 18.44 ns      │ 143469  │ 9182016
   ├─ 889   19.44 ns      │ 1.067 µs      │ 20.78 ns      │ 21.24 ns      │ 127012  │ 8128768
   ├─ 890   19.44 ns      │ 1.145 µs      │ 20.64 ns      │ 21.06 ns      │ 128314  │ 8212096
   ├─ 891   19.28 ns      │ 850 ns        │ 20.63 ns      │ 20.94 ns      │ 129114  │ 8263296
   ├─ 892   18.39 ns      │ 902.1 ns      │ 19.3 ns       │ 19.67 ns      │ 136133  │ 8712512
   ├─ 893   19.28 ns      │ 960.9 ns      │ 20.63 ns      │ 21.04 ns      │ 128447  │ 8220608
   ├─ 894   19.28 ns      │ 755.1 ns      │ 20.63 ns      │ 20.93 ns      │ 129040  │ 8258560
   ├─ 895   19.28 ns      │ 864.8 ns      │ 20.63 ns      │ 21.04 ns      │ 128353  │ 8214592
   ├─ 896   18.39 ns      │ 750.9 ns      │ 19.14 ns      │ 19.65 ns      │ 136199  │ 8716736
   ├─ 897   19.46 ns      │ 1.871 µs      │ 20.78 ns      │ 21.69 ns      │ 124339  │ 7957696
   ├─ 898   19.44 ns      │ 664.3 ns      │ 20.78 ns      │ 21.13 ns      │ 127857  │ 8182848
   ├─ 899   19.44 ns      │ 737.1 ns      │ 20.78 ns      │ 21.17 ns      │ 127540  │ 8162560
   ├─ 900   18.69 ns      │ 861.3 ns      │ 19.74 ns      │ 19.99 ns      │ 134166  │ 8586624
   ├─ 901   19.44 ns      │ 25.75 µs      │ 20.78 ns      │ 22.26 ns      │ 121451  │ 7772864
   ├─ 902   19.72 ns      │ 1.341 µs      │ 21.22 ns      │ 22.11 ns      │ 230027  │ 7360864
   ├─ 903   19.44 ns      │ 2.023 µs      │ 20.78 ns      │ 21.1 ns       │ 128057  │ 8195648
   ├─ 904   18.55 ns      │ 1.156 µs      │ 19.32 ns      │ 19.79 ns      │ 135213  │ 8653632
   ├─ 905   18.25 ns      │ 1.307 µs      │ 19.46 ns      │ 19.78 ns      │ 134888  │ 8632832
   ├─ 906   18.41 ns      │ 540 ns        │ 19.32 ns      │ 19.61 ns      │ 136434  │ 8731776
   ├─ 907   18.27 ns      │ 728.1 ns      │ 19.32 ns      │ 19.72 ns      │ 135685  │ 8683840
   ├─ 908   17.36 ns      │ 971 ns        │ 18.27 ns      │ 18.64 ns      │ 142394  │ 9113216
   ├─ 909   18.27 ns      │ 913.6 ns      │ 19.46 ns      │ 19.87 ns      │ 134677  │ 8619328
   ├─ 910   18.27 ns      │ 1.192 µs      │ 19.32 ns      │ 19.73 ns      │ 135657  │ 8682048
   ├─ 911   18.41 ns      │ 1.08 µs       │ 19.46 ns      │ 20.58 ns      │ 129309  │ 8275776
   ├─ 912   17.22 ns      │ 497.6 ns      │ 17.82 ns      │ 18.16 ns      │ 145565  │ 9316160
   ├─ 913   22.42 ns      │ 1.493 µs      │ 23.35 ns      │ 23.92 ns      │ 114790  │ 7346560
   ├─ 914   22.58 ns      │ 1.173 µs      │ 23.49 ns      │ 24.34 ns      │ 112913  │ 7226432
   ├─ 915   22.44 ns      │ 871 ns        │ 23.35 ns      │ 24.01 ns      │ 114380  │ 7320320
   ├─ 916   21.99 ns      │ 684.4 ns      │ 22.44 ns      │ 23.25 ns      │ 117325  │ 7508800
   ├─ 917   22.42 ns      │ 943.3 ns      │ 23.35 ns      │ 23.95 ns      │ 114693  │ 7340352
   ├─ 918   22.58 ns      │ 1.732 µs      │ 23.33 ns      │ 23.83 ns      │ 115222  │ 7374208
   ├─ 919   22.44 ns      │ 767.2 ns      │ 23.35 ns      │ 24 ns         │ 114479  │ 7326656
   ├─ 920   21.99 ns      │ 1.972 µs      │ 22.44 ns      │ 23.76 ns      │ 114647  │ 7337408
   ├─ 921   19.17 ns      │ 600.4 ns      │ 20.5 ns       │ 21 ns         │ 128528  │ 8225792
   ├─ 922   19.3 ns       │ 1.35 µs       │ 20.64 ns      │ 21.1 ns       │ 127931  │ 8187584
   ├─ 923   19.16 ns      │ 711.5 ns      │ 20.5 ns       │ 20.95 ns      │ 128891  │ 8249024
   ├─ 924   18.41 ns      │ 891 ns        │ 19.32 ns      │ 19.77 ns      │ 135270  │ 8657280
   ├─ 925   19.3 ns       │ 1.196 µs      │ 20.64 ns      │ 21 ns         │ 128612  │ 8231168
   ├─ 926   19.3 ns       │ 532.8 ns      │ 20.5 ns       │ 20.89 ns      │ 129214  │ 8269696
   ├─ 927   19.16 ns      │ 983.3 ns      │ 20.64 ns      │ 20.99 ns      │ 127322  │ 8148608
   ├─ 928   18.53 ns      │ 1.766 µs      │ 19.47 ns      │ 20.33 ns      │ 246561  │ 7889952
   ├─ 929   20.19 ns      │ 747.6 ns      │ 21.53 ns      │ 21.84 ns      │ 124282  │ 7954048
   ├─ 930   20.21 ns      │ 657.3 ns      │ 21.53 ns      │ 22.02 ns      │ 123302  │ 7891328
   ├─ 931   20.21 ns      │ 1.175 µs      │ 21.53 ns      │ 21.94 ns      │ 123704  │ 7917056
   ├─ 932   19.32 ns      │ 1.093 µs      │ 20.19 ns      │ 20.59 ns      │ 130883  │ 8376512
   ├─ 933   20.07 ns      │ 1.078 µs      │ 21.41 ns      │ 21.83 ns      │ 124234  │ 7950976
   ├─ 934   20.19 ns      │ 1.018 µs      │ 21.41 ns      │ 21.97 ns      │ 123470  │ 7902080
   ├─ 935   20.21 ns      │ 884.4 ns      │ 21.41 ns      │ 21.94 ns      │ 123717  │ 7917888
   ├─ 936   19.3 ns       │ 594 ns        │ 20.07 ns      │ 20.56 ns      │ 130944  │ 8380416
   ├─ 937   19.16 ns      │ 1.294 µs      │ 20.21 ns      │ 20.58 ns      │ 130855  │ 8374720
   ├─ 938   19.17 ns      │ 1 µs          │ 20.21 ns      │ 20.64 ns      │ 130555  │ 8355520
   ├─ 939   19.16 ns      │ 750.1 ns      │ 20.21 ns      │ 20.6 ns       │ 130861  │ 8375104
   ├─ 940   18.25 ns      │ 1.008 µs      │ 19.02 ns      │ 19.54 ns      │ 136613  │ 8743232
   ├─ 941   19.16 ns      │ 684.4 ns      │ 20.21 ns      │ 20.65 ns      │ 130520  │ 8353280
   ├─ 942   19.16 ns      │ 827.2 ns      │ 20.21 ns      │ 20.76 ns      │ 129702  │ 8300928
   ├─ 943   19.16 ns      │ 981 ns        │ 20.21 ns      │ 20.54 ns      │ 131225  │ 8398400
   ├─ 944   18.25 ns      │ 571 ns        │ 19.11 ns      │ 19.46 ns      │ 137252  │ 8784128
   ├─ 945   19.27 ns      │ 1.032 µs      │ 20.32 ns      │ 20.83 ns      │ 129408  │ 8282112
   ├─ 946   19.27 ns      │ 1.025 µs      │ 20.32 ns      │ 20.84 ns      │ 129352  │ 8278528
   ├─ 947   19.27 ns      │ 1.058 µs      │ 20.46 ns      │ 20.85 ns      │ 129313  │ 8276032
   ├─ 948   18.5 ns       │ 3.533 µs      │ 19.57 ns      │ 20.75 ns      │ 129063  │ 8260032
   ├─ 949   19.41 ns      │ 1.591 µs      │ 20.32 ns      │ 21.06 ns      │ 128040  │ 8194560
   ├─ 950   19.41 ns      │ 752.3 ns      │ 20.32 ns      │ 20.74 ns      │ 129915  │ 8314560
   ├─ 951   19.41 ns      │ 1.416 µs      │ 20.32 ns      │ 20.73 ns      │ 130011  │ 8320704
   ├─ 952   18.5 ns       │ 431.1 ns      │ 19.42 ns      │ 19.72 ns      │ 135702  │ 8684928
   ├─ 953   20.3 ns       │ 735.6 ns      │ 21.66 ns      │ 22.74 ns      │ 118880  │ 7608320
   ├─ 954   20.16 ns      │ 794 ns        │ 21.5 ns       │ 21.86 ns      │ 124160  │ 7946240
   ├─ 955   20.3 ns       │ 501.5 ns      │ 21.52 ns      │ 22.03 ns      │ 123224  │ 7886336
   ├─ 956   19.25 ns      │ 1.243 µs      │ 20.02 ns      │ 20.46 ns      │ 131506  │ 8416384
   ├─ 957   20.16 ns      │ 1.698 µs      │ 21.5 ns       │ 21.91 ns      │ 123906  │ 7929984
   ├─ 958   20.32 ns      │ 960.5 ns      │ 21.66 ns      │ 22.05 ns      │ 123180  │ 7883520
   ├─ 959   20.3 ns       │ 1.151 µs      │ 21.52 ns      │ 21.95 ns      │ 123698  │ 7916672
   ├─ 960   19.11 ns      │ 725.6 ns      │ 19.86 ns      │ 20.41 ns      │ 131694  │ 8428416
   ├─ 961   20.6 ns       │ 940.5 ns      │ 21.8 ns       │ 22.23 ns      │ 122404  │ 7833856
   ├─ 962   20.46 ns      │ 800.6 ns      │ 21.96 ns      │ 22.5 ns       │ 120763  │ 7728832
   ├─ 963   20.61 ns      │ 927.5 ns      │ 21.82 ns      │ 22.39 ns      │ 121420  │ 7770880
   ├─ 964   19.42 ns      │ 1.553 µs      │ 20.47 ns      │ 20.86 ns      │ 129265  │ 8272960
   ├─ 965   20.46 ns      │ 1.384 µs      │ 21.82 ns      │ 22.28 ns      │ 121995  │ 7807680
   ├─ 966   20.6 ns       │ 961.8 ns      │ 21.82 ns      │ 22.32 ns      │ 121931  │ 7803584
   ├─ 967   20.46 ns      │ 643.9 ns      │ 21.82 ns      │ 22.12 ns      │ 122910  │ 7866240
   ├─ 968   19.25 ns      │ 774.7 ns      │ 20.16 ns      │ 20.56 ns      │ 130979  │ 8382656
   ├─ 969   18.96 ns      │ 1.179 µs      │ 20.02 ns      │ 20.56 ns      │ 130810  │ 8371840
   ├─ 970   19.11 ns      │ 1.104 µs      │ 20.16 ns      │ 20.37 ns      │ 132067  │ 8452288
   ├─ 971   19.11 ns      │ 692.9 ns      │ 20.16 ns      │ 20.45 ns      │ 131561  │ 8419904
   ├─ 972   17.91 ns      │ 635.1 ns      │ 18.82 ns      │ 19.23 ns      │ 138378  │ 8856192
   ├─ 973   19.11 ns      │ 1.034 µs      │ 20.16 ns      │ 20.56 ns      │ 130776  │ 8369664
   ├─ 974   19.11 ns      │ 699.2 ns      │ 20.16 ns      │ 20.6 ns       │ 130557  │ 8355648
   ├─ 975   19.11 ns      │ 767 ns        │ 20.16 ns      │ 20.49 ns      │ 131232  │ 8398848
   ├─ 976   17.75 ns      │ 16.94 µs      │ 18.36 ns      │ 19.75 ns      │ 134505  │ 8608320
   ├─ 977   18.96 ns      │ 909.4 ns      │ 19.72 ns      │ 20.16 ns      │ 133137  │ 8520768
   ├─ 978   18.96 ns      │ 794.9 ns      │ 19.86 ns      │ 20.26 ns      │ 132521  │ 8481344
   ├─ 979   18.96 ns      │ 685.7 ns      │ 19.72 ns      │ 20.12 ns      │ 133432  │ 8539648
   ├─ 980   18.05 ns      │ 24.49 µs      │ 18.82 ns      │ 19.88 ns      │ 134109  │ 8582976
   ├─ 981   18.96 ns      │ 2.548 µs      │ 19.86 ns      │ 20.31 ns      │ 132186  │ 8459904
   ├─ 982   18.96 ns      │ 1.405 µs      │ 19.86 ns      │ 20.18 ns      │ 133126  │ 8520064
   ├─ 983   18.19 ns      │ 1.137 µs      │ 19.86 ns      │ 20.23 ns      │ 132717  │ 8493888
   ├─ 984   17.19 ns      │ 1.398 µs      │ 17.91 ns      │ 18.28 ns      │ 145609  │ 9318976
   ├─ 985   25.82 ns      │ 943.4 ns      │ 26.69 ns      │ 27.42 ns      │ 102012  │ 6528768
   ├─ 986   26.25 ns      │ 1.834 µs      │ 27.13 ns      │ 27.81 ns      │ 191735  │ 6135520
   ├─ 987   25.53 ns      │ 1.166 µs      │ 26.69 ns      │ 27.19 ns      │ 102915  │ 6586560
   ├─ 988   25.53 ns      │ 824.4 ns      │ 26.41 ns      │ 27.07 ns      │ 103134  │ 6600576
   ├─ 989   25.67 ns      │ 881.1 ns      │ 26.69 ns      │ 27.23 ns      │ 102730  │ 6574720
   ├─ 990   25.82 ns      │ 1.476 µs      │ 26.69 ns      │ 27.22 ns      │ 102790  │ 6578560
   ├─ 991   26.1 ns       │ 1.254 µs      │ 26.69 ns      │ 27.41 ns      │ 102037  │ 6530368
   ├─ 992   25.67 ns      │ 877.1 ns      │ 26.39 ns      │ 27.27 ns      │ 102459  │ 6557376
   ├─ 993   25.67 ns      │ 718.1 ns      │ 28.99 ns      │ 29.52 ns      │ 95564   │ 6116096
   ├─ 994   26.25 ns      │ 894.2 ns      │ 28.85 ns      │ 29.47 ns      │ 95705   │ 6125120
   ├─ 995   25.67 ns      │ 729.2 ns      │ 28.99 ns      │ 30.22 ns      │ 93300   │ 5971200
   ├─ 996   26.25 ns      │ 923.2 ns      │ 27.99 ns      │ 28.6 ns       │ 98275   │ 6289600
   ├─ 997   25.39 ns      │ 923.3 ns      │ 28.99 ns      │ 29.76 ns      │ 94755   │ 6064320
   ├─ 998   25.67 ns      │ 1.033 µs      │ 28.83 ns      │ 29.52 ns      │ 95506   │ 6112384
   ├─ 999   25.39 ns      │ 1.153 µs      │ 28.85 ns      │ 29.72 ns      │ 94872   │ 6071808
   ├─ 1000  25.53 ns      │ 1.197 µs      │ 28.13 ns      │ 28.76 ns      │ 97775   │ 6257600
   ├─ 1001  25.39 ns      │ 776.6 ns      │ 27.85 ns      │ 28.67 ns      │ 97995   │ 6271680
   ├─ 1002  25.38 ns      │ 5.128 µs      │ 27.97 ns      │ 29.88 ns      │ 94029   │ 6017856
   ├─ 1003  25.67 ns      │ 726.7 ns      │ 27.97 ns      │ 28.46 ns      │ 98723   │ 6318272
   ├─ 1004  25.53 ns      │ 944 ns        │ 26.97 ns      │ 27.68 ns      │ 101270  │ 6481280
   ├─ 1005  25.82 ns      │ 687.8 ns      │ 27.99 ns      │ 28.78 ns      │ 97633   │ 6248512
   ├─ 1006  25.53 ns      │ 6.314 µs      │ 27.85 ns      │ 30.22 ns      │ 92770   │ 5937280
   ├─ 1007  25.39 ns      │ 1.821 µs      │ 27.83 ns      │ 28.66 ns      │ 98129   │ 6280256
   ├─ 1008  25.53 ns      │ 1.138 µs      │ 26.97 ns      │ 27.68 ns      │ 101231  │ 6478784
   ├─ 1009  25.94 ns      │ 2.535 µs      │ 28.28 ns      │ 28.95 ns      │ 185406  │ 5932992
   ├─ 1010  26.78 ns      │ 2.061 µs      │ 29.78 ns      │ 30.41 ns      │ 176532  │ 5649024
   ├─ 1011  27.07 ns      │ 1.565 µs      │ 29.5 ns       │ 30.3 ns       │ 177324  │ 5674368
   ├─ 1012  27.07 ns      │ 1.441 µs      │ 28.88 ns      │ 29.5 ns       │ 181229  │ 5799328
   ├─ 1013  27.07 ns      │ 1.94 µs       │ 29.5 ns       │ 30.25 ns      │ 177481  │ 5679392
   ├─ 1014  26.78 ns      │ 1.767 µs      │ 29.5 ns       │ 30.31 ns      │ 177144  │ 5668608
   ├─ 1015  26.78 ns      │ 1.524 µs      │ 29.5 ns       │ 30.13 ns      │ 178145  │ 5700640
   ├─ 1016  27.07 ns      │ 1.727 µs      │ 28.88 ns      │ 29.45 ns      │ 181438  │ 5806016
   ├─ 1017  26.78 ns      │ 1.38 µs       │ 29.5 ns       │ 30.29 ns      │ 177269  │ 5672608
   ├─ 1018  26.78 ns      │ 1.53 µs       │ 29.5 ns       │ 30.28 ns      │ 177175  │ 5669600
   ├─ 1019  27.07 ns      │ 2.013 µs      │ 29.5 ns       │ 30.37 ns      │ 176798  │ 5657536
   ├─ 1020  27.07 ns      │ 2.969 µs      │ 29.5 ns       │ 30.38 ns      │ 176706  │ 5654592
   ├─ 1021  27.41 ns      │ 1.625 µs      │ 29.5 ns       │ 29.95 ns      │ 179209  │ 5734688
   ├─ 1022  26.78 ns      │ 1.01 µs       │ 29.5 ns       │ 30.32 ns      │ 176970  │ 5663040
   ├─ 1023  26.78 ns      │ 1.382 µs      │ 29.5 ns       │ 30.02 ns      │ 178814  │ 5722048
   ├─ 1024  26.35 ns      │ 2.894 µs      │ 27.25 ns      │ 28.16 ns      │ 188431  │ 6029792
   ├─ 1025  26.35 ns      │ 2.11 µs       │ 27.25 ns      │ 27.69 ns      │ 191635  │ 6132320
   ├─ 1026  26.35 ns      │ 1.666 µs      │ 27.25 ns      │ 27.71 ns      │ 191521  │ 6128672
   ├─ 1027  26.35 ns      │ 7.447 µs      │ 27.25 ns      │ 28.9 ns       │ 183926  │ 5885632
   ├─ 1028  26.35 ns      │ 2.293 µs      │ 27.25 ns      │ 27.97 ns      │ 189810  │ 6073920
   ├─ 1029  26.35 ns      │ 2.136 µs      │ 27.25 ns      │ 28.02 ns      │ 189289  │ 6057248
   ├─ 1030  26.35 ns      │ 1.221 µs      │ 27.25 ns      │ 27.8 ns       │ 190866  │ 6107712
   ├─ 1031  26.35 ns      │ 2.331 µs      │ 27.25 ns      │ 27.74 ns      │ 191168  │ 6117376
   ├─ 1032  26.35 ns      │ 30.49 µs      │ 27.25 ns      │ 28.25 ns      │ 188556  │ 6033792
   ├─ 1033  26.63 ns      │ 12.9 µs       │ 26.97 ns      │ 28.97 ns      │ 183187  │ 5861984
   ├─ 1034  26.35 ns      │ 642.5 ns      │ 26.64 ns      │ 27.31 ns      │ 102004  │ 6528256
   ├─ 1035  26.35 ns      │ 720.6 ns      │ 26.66 ns      │ 27.11 ns      │ 102793  │ 6578752
   ├─ 1036  26.35 ns      │ 1.031 µs      │ 26.8 ns       │ 27.4 ns       │ 101697  │ 6508608
   ├─ 1037  26.35 ns      │ 542.9 ns      │ 26.64 ns      │ 27.09 ns      │ 102938  │ 6588032
   ├─ 1038  26.63 ns      │ 1.012 µs      │ 26.94 ns      │ 27.46 ns      │ 193068  │ 6178176
   ├─ 1039  26.35 ns      │ 1.224 µs      │ 26.66 ns      │ 27.59 ns      │ 101064  │ 6468096
   ├─ 1040  26.35 ns      │ 776.7 ns      │ 26.64 ns      │ 27.15 ns      │ 102577  │ 6564928
   ├─ 1041  26.63 ns      │ 1.867 µs      │ 26.94 ns      │ 27.74 ns      │ 191243  │ 6119776
   ├─ 1042  26.63 ns      │ 3.292 µs      │ 27.22 ns      │ 28.04 ns      │ 189122  │ 6051904
   ├─ 1043  26.63 ns      │ 2.446 µs      │ 26.97 ns      │ 28.34 ns      │ 187251  │ 5992032
   ├─ 1044  26.63 ns      │ 1.619 µs      │ 26.97 ns      │ 27.61 ns      │ 191924  │ 6141568
   ├─ 1045  26.63 ns      │ 2.134 µs      │ 26.97 ns      │ 27.61 ns      │ 192015  │ 6144480
   ├─ 1046  26.63 ns      │ 1.969 µs      │ 26.94 ns      │ 27.74 ns      │ 191051  │ 6113632
   ├─ 1047  26.63 ns      │ 1.096 µs      │ 26.97 ns      │ 27.62 ns      │ 191810  │ 6137920
   ├─ 1048  26.35 ns      │ 1.717 µs      │ 26.94 ns      │ 27.51 ns      │ 192702  │ 6166464
   ├─ 1049  27.24 ns      │ 940.7 ns      │ 28.44 ns      │ 29.15 ns      │ 96276   │ 6161664
   ├─ 1050  26.35 ns      │ 927.5 ns      │ 28.6 ns       │ 29.08 ns      │ 96575   │ 6180800
   ├─ 1051  26.5 ns       │ 1.485 µs      │ 28.58 ns      │ 29.14 ns      │ 96344   │ 6166016
   ├─ 1052  26.66 ns      │ 928.5 ns      │ 28.28 ns      │ 28.71 ns      │ 97642   │ 6249088
   ├─ 1053  26.66 ns      │ 3.488 µs      │ 28.6 ns       │ 30.67 ns      │ 91497   │ 5855808
   ├─ 1054  26.64 ns      │ 931.1 ns      │ 28.46 ns      │ 29.36 ns      │ 95556   │ 6115584
   ├─ 1055  26.5 ns       │ 590.9 ns      │ 28.58 ns      │ 29.07 ns      │ 96550   │ 6179200
   ├─ 1056  26.35 ns      │ 1.283 µs      │ 28.14 ns      │ 29.15 ns      │ 96122   │ 6151808
   ├─ 1057  27.25 ns      │ 1.876 µs      │ 28.46 ns      │ 29.15 ns      │ 96316   │ 6164224
   ├─ 1058  26.82 ns      │ 2.176 µs      │ 28.6 ns       │ 29.56 ns      │ 94912   │ 6074368
   ├─ 1059  27.25 ns      │ 22.57 µs      │ 28.6 ns       │ 30.32 ns      │ 92708   │ 5933312
   ├─ 1060  27.85 ns      │ 2.368 µs      │ 28.44 ns      │ 29.76 ns      │ 179637  │ 5748384
   ├─ 1061  26.94 ns      │ 1.186 µs      │ 28.6 ns       │ 29.5 ns       │ 95125   │ 6088000
   ├─ 1062  26.94 ns      │ 1.237 µs      │ 28.6 ns       │ 29.19 ns      │ 96209   │ 6157376
   ├─ 1063  27.39 ns      │ 1.123 µs      │ 28.6 ns       │ 29.29 ns      │ 95759   │ 6128576
   ├─ 1064  26.82 ns      │ 838.4 ns      │ 28.16 ns      │ 28.87 ns      │ 97092   │ 6213888
   ├─ 1065  26.78 ns      │ 1.954 µs      │ 27.69 ns      │ 28.2 ns       │ 188866  │ 6043712
   ├─ 1066  26.78 ns      │ 6.162 µs      │ 27.69 ns      │ 29.86 ns      │ 178516  │ 5712512
   ├─ 1067  26.78 ns      │ 2.318 µs      │ 27.69 ns      │ 29.01 ns      │ 183602  │ 5875264
   ├─ 1068  26.78 ns      │ 1.156 µs      │ 27.41 ns      │ 27.79 ns      │ 191390  │ 6124480
   ├─ 1069  26.78 ns      │ 1.63 µs       │ 27.69 ns      │ 28.17 ns      │ 188935  │ 6045920
   ├─ 1070  26.78 ns      │ 1.745 µs      │ 27.69 ns      │ 28.27 ns      │ 188302  │ 6025664
   ├─ 1071  26.78 ns      │ 1.569 µs      │ 27.41 ns      │ 28.14 ns      │ 189220  │ 6055040
   ├─ 1072  26.66 ns      │ 709.2 ns      │ 27.11 ns      │ 27.88 ns      │ 100238  │ 6415232
   ├─ 1073  26.78 ns      │ 1.861 µs      │ 27.69 ns      │ 28.32 ns      │ 187811  │ 6009952
   ├─ 1074  26.78 ns      │ 1.718 µs      │ 27.69 ns      │ 28.32 ns      │ 187934  │ 6013888
   ├─ 1075  26.78 ns      │ 2.378 µs      │ 27.69 ns      │ 28.3 ns       │ 188216  │ 6022912
   ├─ 1076  26.78 ns      │ 3.556 µs      │ 27.41 ns      │ 28.26 ns      │ 188307  │ 6025824
   ├─ 1077  26.78 ns      │ 1.919 µs      │ 27.69 ns      │ 28.08 ns      │ 189379  │ 6060128
   ├─ 1078  26.78 ns      │ 4.061 µs      │ 27.69 ns      │ 29.39 ns      │ 181335  │ 5802720
   ├─ 1079  26.78 ns      │ 1.847 µs      │ 27.69 ns      │ 28.25 ns      │ 188281  │ 6024992
   ├─ 1080  26.78 ns      │ 1.907 µs      │ 27.41 ns      │ 28.14 ns      │ 189353  │ 6059296
   ├─ 1081  26.82 ns      │ 497.9 ns      │ 28.6 ns       │ 30.32 ns      │ 92635   │ 5928640
   ├─ 1082  28 ns         │ 1.353 µs      │ 28.91 ns      │ 29.73 ns      │ 180314  │ 5770048
   ├─ 1083  26.96 ns      │ 657.6 ns      │ 28.6 ns       │ 29.6 ns       │ 94884   │ 6072576
   ├─ 1084  26.82 ns      │ 761.9 ns      │ 28.16 ns      │ 28.85 ns      │ 97227   │ 6222528
   ├─ 1085  26.82 ns      │ 1.033 µs      │ 28.46 ns      │ 29.17 ns      │ 96300   │ 6163200
   ├─ 1086  27.11 ns      │ 29.36 µs      │ 28.58 ns      │ 30.59 ns      │ 91525   │ 5857600
   ├─ 1087  27.11 ns      │ 1.681 µs      │ 28.46 ns      │ 29.1 ns       │ 96493   │ 6175552
   ├─ 1088  26.96 ns      │ 733.2 ns      │ 28.14 ns      │ 28.74 ns      │ 97554   │ 6243456
   ├─ 1089  27.25 ns      │ 959.1 ns      │ 28.74 ns      │ 29.64 ns      │ 94824   │ 6068736
   ├─ 1090  27.11 ns      │ 1.138 µs      │ 28.6 ns       │ 29.41 ns      │ 95428   │ 6107392
   ├─ 1091  26.97 ns      │ 685.4 ns      │ 28.6 ns       │ 29.31 ns      │ 95846   │ 6134144
   ├─ 1092  26.96 ns      │ 743.6 ns      │ 28.28 ns      │ 28.78 ns      │ 97485   │ 6239040
   ├─ 1093  26.96 ns      │ 2.918 µs      │ 28.6 ns       │ 29.35 ns      │ 95728   │ 6126592
   ├─ 1094  26.97 ns      │ 986.6 ns      │ 28.6 ns       │ 29.3 ns       │ 95851   │ 6134464
   ├─ 1095  28.28 ns      │ 1.343 µs      │ 29.19 ns      │ 29.75 ns      │ 180315  │ 5770080
   ├─ 1096  26.66 ns      │ 735.6 ns      │ 28.16 ns      │ 28.73 ns      │ 97658   │ 6250112
   ├─ 1097  26.78 ns      │ 1.136 µs      │ 27.41 ns      │ 27.97 ns      │ 189970  │ 6079040
   ├─ 1098  26.78 ns      │ 1.563 µs      │ 27.41 ns      │ 28.07 ns      │ 189067  │ 6050144
   ├─ 1099  26.78 ns      │ 3.188 µs      │ 27.13 ns      │ 27.78 ns      │ 191220  │ 6119040
   ╰─ 1100  26.78 ns      │ 1.598 µs      │ 27.13 ns      │ 27.82 ns      │ 190872  │ 6107904


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

```